### PR TITLE
Added Ara-Lat transducer and modified Ara-Cyr transducer

### DIFF
--- a/apertium-uig.uig.lexc
+++ b/apertium-uig.uig.lexc
@@ -6,7 +6,7 @@ Multichar_Symbols
 
 %<n%>             ! Noun
 %<post%>          ! Postposition
-%<det%>
+%<det%>         ! Determiner
 %<v%>             ! Verb
 %<vaux%>          ! Auxiliary verb
 %<cnjcoo%>        ! Co-ordinating conjunction

--- a/dev/ortho/Makefile
+++ b/dev/ortho/Makefile
@@ -1,15 +1,53 @@
-all: uig-ARA.automorf.hfst uig-ARA.automorf.bin uig-ARA.autogen.hfst #ara-cyr.lexc.hfst
+all: uig-CYR.automorf.hfst uig-CYR.automorf.bin uig-CYR.autogen.hfst uig-LAT.automorf.hfst uig-LAT.automorf.bin uig-LAT.autogen.hfst ara-cyr.hfst ara-lat.hfst
+
+#all: ara-lat.hfst ara-cyr.hfst ara-lat-rev.hfst ara-cyr-rev.hfst
 
 ara-cyr.lexc.hfst: ara-cyr.lexc
 	hfst-lexc $< -o $@
 
-uig-ARA.autogen.hfst: ../../.deps/uig.LR.hfst ara-cyr.lexc.hfst
-	hfst-minimise $< | hfst-compose-intersect -1 - -2 ara-cyr.lexc.hfst -o $@
+ara-cyr.twol.hfst: ara-cyr.twol
+	hfst-twolc $< -o $@
 
-uig-ARA.REVautomorf.hfst: ../../.deps/uig.RL.hfst ara-cyr.lexc.hfst
-	hfst-minimise $< | hfst-compose-intersect -1 - -2 ara-cyr.lexc.hfst -o $@
+# ara-cyr.hfst: ara-cyr.twol.hfst ara-cyr.lexc.hfst
+# 	hfst-compose-intersect -1 $(word 2,$^) -2 $< | hfst-fst2fst -o $@ -O
 
-uig-ARA.automorf.hfst: uig-ARA.REVautomorf.hfst
+# ara-cyr-rev.hfst: ara-cyr.twol.hfst ara-cyr.lexc.hfst
+# 	hfst-compose-intersect -1 $(word 2,$^) -2 $<  | hfst-invert | hfst-fst2fst -o $@ -O
+
+ara-cyr.hfst: ara-cyr.twol.hfst ara-cyr.lexc.hfst
+	hfst-compose-intersect -1 $(word 2,$^) -2 $< -o $@
+
+ara-lat.lexc.hfst: ara-lat.lexc
+	hfst-lexc $< -o $@
+
+ara-lat.twol.hfst: ara-lat.twol
+	hfst-twolc $< -o $@
+
+# ara-lat.hfst: ara-lat.twol.hfst ara-lat.lexc.hfst
+# 	hfst-compose-intersect -1 $(word 2,$^) -2 $<  | hfst-fst2fst -o $@ -O
+
+# ara-lat-rev.hfst: ara-lat.twol.hfst ara-lat.lexc.hfst
+# 	hfst-compose-intersect -1 $(word 2,$^) -2 $<  | hfst-invert | hfst-fst2fst -o $@ -O
+
+ara-lat.hfst: ara-lat.twol.hfst ara-lat.lexc.hfst
+	hfst-compose-intersect -1 $(word 2,$^) -2 $<  -o $@
+
+uig-CYR.autogen.hfst: ../../.deps/uig.LR.hfst ara-cyr.hfst
+	hfst-minimise $< | hfst-compose-intersect -1 - -2 $(word 2,$^) -o $@
+
+uig-CYR.REVautomorf.hfst: ../../.deps/uig.RL.hfst ara-cyr.hfst
+	hfst-minimise $< | hfst-compose-intersect -1 - -2 $(word 2,$^) -o $@
+
+uig-CYR.automorf.hfst: uig-CYR.REVautomorf.hfst
+	hfst-invert $< -o $@
+
+uig-LAT.autogen.hfst: ../../.deps/uig.LR.hfst ara-lat.hfst
+	hfst-minimise $< | hfst-compose-intersect -1 - -2 $(word 2,$^) -o $@
+
+uig-LAT.REVautomorf.hfst: ../../.deps/uig.RL.hfst ara-lat.hfst
+	hfst-minimise $< | hfst-compose-intersect -1 - -2 $(word 2,$^) -o $@
+
+uig-LAT.automorf.hfst: uig-LAT.REVautomorf.hfst
 	hfst-invert $< -o $@
 
 %.att.gz: %.hfst
@@ -18,7 +56,6 @@ uig-ARA.automorf.hfst: uig-ARA.REVautomorf.hfst
 %.bin: %.att.gz
 	zcat < $< > %.att
 	lt-comp lr %.att $@
-	
 
 clean:
 	rm *.hfst *.att *.att.gz

--- a/dev/ortho/ara-cyr.twol
+++ b/dev/ortho/ara-cyr.twol
@@ -1,0 +1,94 @@
+Alphabet
+
+ا:а 
+ە:ә 
+ب:б 
+پ:п 
+ت:т 
+ج:җ 
+چ:ч 
+خ:х 
+د:д 
+ر:р 
+ز:з 
+ژ:ж 
+س:с 
+ش:ш 
+غ:ғ 
+ف:ф 
+ق:қ 
+ك:к 
+گ:г 
+ڭ:ң 
+ل:л 
+م:м 
+ن:н 
+ھ:һ 
+و:о 
+ۇ:у 
+ۆ:ө 
+ۈ:ү 
+ۋ:в 
+ې:е 
+ى:и 
+ي:й 
+ک:к 
+ئ:0
+%{ja%}:я
+%{ju%}:ю
+
+ا:А 
+ە:Ә 
+ب:Б 
+پ:П 
+ت:Т 
+ج:Җ 
+چ:Ч 
+خ:Х 
+د:Д 
+ر:Р 
+ز:З 
+ژ:Ж 
+س:С 
+ش:Ш 
+غ:Ғ 
+ف:Ф 
+ق:Қ 
+ك:К 
+گ:Г 
+ڭ:Ң 
+ل:Л 
+م:М 
+ن:Н 
+ھ:Һ 
+و:О 
+ۇ:У 
+ۆ:Ө 
+ۈ:Ү 
+ۋ:В 
+ې:Е 
+ى:И 
+ي:Й 
+ک:К 
+%{ja%}:Я
+%{ju%}:Ю
+;
+
+Sets
+
+Caps =  А  Ә  Б  П  Т  Җ  Ч  Х  Д  Р  З  Ж  С  Ш  Ғ  Ф  Қ  К  Г  Ң  Л  М  Н  Һ  О  У  Ө  Ү  В  У И  Й Я Ю ;
+
+Vows = а ә о у ө ү е и А Ә  О  У  Ө  Ү  У И ;
+
+Rules
+
+! This rule is actually a heuristic. Most words with VV sequences have a hamza 
+! between them, but certain (mostly Mandarin?) loanwords don't: e.g., ئيۈەن
+"Mandatory hamza between vowels"
+ئ:0 <=> :Vows _ :Vows ;
+
+"Mandatory hamza word-initially before vowel"
+ئ:0 <=> .#.  _ :Vows ;
+
+"Only capitalize word-initially"
+:Caps => .#. _ ;

--- a/dev/ortho/ara-lat.lexc
+++ b/dev/ortho/ara-lat.lexc
@@ -1,9 +1,6 @@
 Multichar_Symbols 
 
-يا
-يۇ
-%{ja%}
-%{ju%}
+%{n%} ! possible apostrophe to disambiguate ڭ from نگ
 
 LEXICON Root 
 
@@ -43,7 +40,7 @@ LEXICON Alpha
 ڭ:ڭ AlphaLoop ;
 ل:ل AlphaLoop ;
 م:م AlphaLoop ;
-ن:ن AlphaLoop ;
+ن:ن%{n%} AlphaLoop ;
 ھ:ھ AlphaLoop ;
 و:و AlphaLoop ;
 ۇ:ۇ AlphaLoop ;
@@ -56,8 +53,6 @@ LEXICON Alpha
 ک:ک AlphaLoop ;
 ئ:ئ AlphaLoop ;
 
-يۇ:%{ju%} AlphaLoop ;
-يا:%{ja%} AlphaLoop ;
 # ;
 
 LEXICON Digits

--- a/dev/ortho/ara-lat.twol
+++ b/dev/ortho/ara-lat.twol
@@ -1,0 +1,93 @@
+Alphabet
+
+ا:a
+ە:e
+ب:b
+پ:p
+ت:t
+ج:j
+چ:ch
+خ:x
+د:d
+ر:r
+ز:z
+ژ:zh
+س:s
+ش:sh
+غ:gh
+ف:f
+ق:q
+ك:k
+گ:g
+ڭ:ng
+ل:l
+م:m
+ن:n
+ھ:h
+و:o
+ۇ:u
+ۆ:ö
+ۈ:ü
+ۋ:w
+ې:é
+ى:i
+ي:y
+ک:k
+ئ:'
+
+ا:A
+ە:E
+ب:B
+پ:P
+ت:T
+ج:J
+چ:CH
+خ:X
+د:D
+ر:R
+ز:Z
+ژ:ZH
+س:S
+ش:SH
+غ:GH
+ف:F
+ق:Q
+ك:K
+گ:G
+ڭ:NG
+ل:L
+م:M
+ن:N
+ھ:H
+و:O
+ۇ:U
+ۆ:Ö
+ۈ:Ü
+ۋ:W
+ې:É
+ى:I
+ي:Y
+ک:K
+
+%{n%}:0 ;
+
+Sets
+
+Vows = i é ü ö e u o a  ;
+
+Caps = A E B P T J CH X D R Z W S SH GH F Q K G NG L M N H I O U Ö Ü É I Y ;
+
+Gsounds = g G ;
+
+Rules
+
+"Remove word-initial hamzas"
+ئ:0 <=> .#. _ :Vows ;
+
+! Do we need to wory about other potentially ambiguous sequences?
+! gh, sh, zh, ngh
+"Split n-g sequences with apostrophe"
+%{n%}:' <=>_ :Gsounds ;
+
+"Only capitalize word-initially"
+:Caps => .#. _ ;


### PR DESCRIPTION
I added an Arabic-Latin transducer and modified the Arabic-Cyrillic transducer to fix a few issues. I may have done some things in suboptimal ways out of lack of experience with `hfst`, so please correct me!

I think things basically work fine when they plug into the morphological transducer, but there are a few little issues when the transducers are inverted:

- The hamza rules for both Ara-Lat and Ara-Cyr are intended to be enforce mandatory hamza insertion when going from Lat/Cyr -> Ara. E.g., _always_ insert a hamza word initially before a vowel. In practice, the inverted transducer spits out forms both with and without the hamza:
```
echo "Уйғурчә" | hfst-proc ara-cyr-rev.hfst
^Уйғурчә/ئۇيغۇرچە/ۇيغۇرچە$
```
Here the apostrophe between `n` and `g` should be removed, but this removal is again treated as optional and it's subsequently replaced by a hamza (Uyghur latin script uses apostrophes both to represent (some) hamzas and to disambiguate sequences of `n` and `g` from the single sound `ng`.
```
echo "in'gliz" | hfst-proc ara-lat-rev.hfst
^in'gliz/ئىنئگلىز/ئىنگلىز/ىنئگلىز/ىنگلىز$
```
This is basically fine because one of them is the correct form (and the hamzas are removed by the morphological transducer anyways), but it would be nice to be able to rule out the hamza-less forms completely. Or is this even worth worrying about?

- Both Arabic and Latin use bigrams that correspond to unigrams in Cyrillic/Arabic respectively. Running hfst-proc on the transducers produces the warning:
```
!! Warning: Transducer contains one or more multi-character symbols made up of
ASCII characters which are also available as single-character symbols. The
input stream will always be tokenised using the longest symbols available.
Use the -t option to view the tokenisation. The problematic symbol(s):
يا يۇ
```
This isn't really a problem (the longest tokenization is what we want), but it's sort of obnoxious. Any way to set things up differently? 


